### PR TITLE
Added reusable redirect.ts component, removed state-based hook

### DIFF
--- a/client/src/pages/AuthRegister/AuthRegister.tsx
+++ b/client/src/pages/AuthRegister/AuthRegister.tsx
@@ -15,16 +15,12 @@ import { IonGrid, IonRow, IonCol } from "@ionic/react";
 import { personCircle } from "ionicons/icons";
 import { Formik, FormikConfig } from "formik";
 import { useAuthentication } from "utils/firebase";
+import { useRedirect } from "utils/redirect";
 import { routes } from "utils/routes";
-import { useHistory } from "react-router-dom";
 
 const AuthRegister: React.FC = () => {
   const { signUp } = useAuthentication();
-
-  const history = useHistory();
-  const redirect = () => {
-    history.push("/settings");
-  };
+  const { redirect } = useRedirect();  
 
   const onSubmit: FormikConfig<any>["onSubmit"] = async (
     values,
@@ -33,7 +29,7 @@ const AuthRegister: React.FC = () => {
     const newUser = await signUp(values.email, values.password);
     console.log("newUser", newUser);
     setSubmitting(false);
-    redirect();
+    redirect("/settings");
   };
 
   return (

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -1,0 +1,10 @@
+import { useHistory } from "react-router"
+
+
+export const useRedirect = () => {
+    const history = useHistory();
+    const redirect = (path: string) => {
+        history.push(path);
+    }
+    return { redirect };
+}


### PR DESCRIPTION
Feat: reusable _redirect_ component with **useHistory** instead of using **state**. Added to AuthRegister to redirect to **/settings** after subscribing for now.

Please escuse this new branch, I lost my way in GitKraken. The branch "front-end-kevin" can be deleted if possible.